### PR TITLE
Player List - master

### DIFF
--- a/hangman.js
+++ b/hangman.js
@@ -33,6 +33,7 @@ class hangman {
     async showProgress() {
         const embed = new Discord.MessageEmbed()
             .setDescription('```\n' + this.getFigure() + '```')
+            .addField('Players', this.playerlist())
             .setColor(this.gameOver ? (this.status === 'won' ? '#00CC00' : '#E50000') : '');
 
         if (this.message) await this.message.edit({
@@ -41,6 +42,13 @@ class hangman {
         else this.message = await this.channel.send({
             embed: embed
         });
+    }
+    
+    playerlist() {
+        const filter = this.players.slice(0, 3)
+        const remaining = this.players.length - filter.length === 0 ? '' : `+ ${this.players.length - filter.length} more`
+
+        return filter.join('\n') + remaining
     }
 
     getFigure() {

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,6 +68,8 @@ class Hangman {
     public replaceChar(char: string): void;
 
     public async showProgress(): Promise<void>;
+    
+    public playerlist(): string;
 
     public getFigure(): string;
 


### PR DESCRIPTION
Added a nice and simple player list!

The player list will list up to 3 players in a game to avoid large messages and clutter
![Demo 1](https://user-images.githubusercontent.com/82066539/127783940-ebec037b-9be9-4ec0-937e-1f5740372e15.JPG)

If there are more than 3 players in a game, the list will show the remaining amount of players via a counter
![Demo 2](https://user-images.githubusercontent.com/82066539/127784017-98f25e2e-de02-4fe9-b59c-efddd9eb0c6b.JPG)

Players are listed vertically to avoid stretching the embed which the embed would stretch especially if a user had a really long username and or nickname. Also IMO listing the players vertically looks cleaner than listing it horizontally.

Hope you like this!