### PR TITLE
Player List Fix - master

### DIFF
--- a/defaultOptions.js
+++ b/defaultOptions.js
@@ -16,6 +16,7 @@ module.exports = {
 
     misses: 'Misses',
     won: 'You won !',
+    noplayersleft: 'No Players Left',
     gameOver: 'Game over !',
     gameOverMsg: 'The word was {word}'
 }

--- a/docs/gettingStarted.md
+++ b/docs/gettingStarted.md
@@ -77,6 +77,7 @@ You can easily translate the messages of the module into your language by using 
 
     misses: 'Misses',
     won: 'You won !',
+    noplayersleft: 'No Players Left',
     gameOver: 'Game over !',
     gameOverMsg: 'The word was {word}'
 }

--- a/hangman.js
+++ b/hangman.js
@@ -45,6 +45,7 @@ class hangman {
     }
     
     playerlist() {
+        if (!this.players.length) return this.messages.noplayers
         const filter = this.players.slice(0, 3)
         const remaining = this.players.length - filter.length === 0 ? '' : `+ ${this.players.length - filter.length} more`
 

--- a/hangman.js
+++ b/hangman.js
@@ -45,7 +45,7 @@ class hangman {
     }
     
     playerlist() {
-        if (!this.players.length) return this.messages.noplayers
+        if (!this.players.length) return this.messages.noplayersleft
         const filter = this.players.slice(0, 3)
         const remaining = this.players.length - filter.length === 0 ? '' : `+ ${this.players.length - filter.length} more`
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,7 @@ interface HangmanMessages {
 
     misses: string;
     won: string;
+    noplayersleft: string;
     gameOver: string;
     gameOverMsg: string;
 }


### PR DESCRIPTION
Sorry for the new PR. I accidently created a bug with the player list. If you incorrectly guess a full word, you will be knocked out of the game and the embed will update with the list of players. If there are no players left, Discord will throw out an empty field error since the player list grabs the players playing (which would be none) and tries to display the empty value in the field.

So I added a new string to default options that the player list can grab and throw if there are no more players left.

Don't forget to publish this. My next major PR will most likely be my last. I'll update this master branch to discord v13 as well as clean up some code.

Thanks again as always for this nice game!